### PR TITLE
90447 - Amelioration synthese des roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Here is a complete list of the features:
 * Hide optional advanced fields in **version** form
 * Define a **default project** selected when creating a new issue without being in a specific project
 * Add **check-all / uncheck-all shortcuts** to roles filters
+* Improve roles synthesis by adding missing informations about issues permissions and trackers
 
 ## Test status
 

--- a/app/overrides/roles/permissions.rb
+++ b/app/overrides/roles/permissions.rb
@@ -12,3 +12,12 @@ Deface::Override.new :virtual_path => 'roles/permissions',
 <%= form_tag({}, :method => :get, :id => "roles-form") do %>
 eos
 
+Deface::Override.new :virtual_path => 'roles/permissions',
+                     :name => 'add-general-data-box',
+                     :insert_top => "div.autoscroll",
+                     :partial    => "roles/general_data"
+
+Deface::Override.new :virtual_path => 'roles/permissions',
+                     :name => 'add-trackers-permissions-box',
+                     :insert_after => ".permissions",
+                     :partial    => "roles/trackers_permissions.html"

--- a/app/views/roles/_general_data.html.erb
+++ b/app/views/roles/_general_data.html.erb
@@ -1,0 +1,64 @@
+<div class="autoscroll">
+<table class="list permmision">
+  <thead>
+      <tr>
+      <th class="col-permmision"><%=l(:label_general_data)%></th>
+      <% @roles.each do |role| %>
+      <th>
+          <%= content_tag(role.builtin? ? 'em' : 'span', role.name) %>
+      </th>
+      <% end %>
+      </tr>
+  </thead>
+  <tbody>
+    <tr class="assignable">
+      <td class="name">
+          <%= link_to_function('',
+                               "toggleCheckboxesBySelector('.assignable input')",
+                               :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}",
+                               :class => 'icon-only icon-checked') %>
+         <%=l(:field_assignable)%>
+      </td>
+      <% @roles.each do |role| %>
+        <% if !role.builtin? %>
+          <td title="<%= l(:field_assignable) + " (#{role.name})" %>">
+            <%= check_box_tag "assignable[#{role.id}][]", 1, (role.assignable), :id => nil %>
+          </td>
+        <% else %>
+          <td></td>
+        <% end %>
+      <% end %>
+    </tr>
+    <tr class="group open" class="view_issues_shown">
+      <td>
+        <span class="expander icon icon-expended" onclick="toggleRowGroup(this);">&nbsp;</span>
+        <%=l(:field_issues_visibility)%>
+      </td>
+      <% @roles.each do |role| %>
+      <td class="role"></td>
+      <% end %>
+    </tr>
+    <% Role::ISSUES_VISIBILITY_OPTIONS.each do |option| %>
+      <tr class="visibility_<%= option.first %>">
+        <td class="name">
+          <%= link_to_function('',
+                               "toggleCheckboxesBySelector('.visibility_#{option.first} input')",
+                               :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}",
+                               :class => 'icon-only icon-checked') %>
+          <%=l(option.second)%>
+        </td>
+        <% @roles.each do |role| %>
+        <td>
+          <% unless role.anonymous? %>
+            <label class="block">
+              <%= radio_button_tag "issues_visibility[#{role.id}]", option.first, role.issues_visibility == option.first, class:"view_issues-#{role.id}_shown"
+                     %>
+            </label>
+          <% end %>
+        </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+</div>

--- a/app/views/roles/_trackers_permissions.html.erb
+++ b/app/views/roles/_trackers_permissions.html.erb
@@ -1,0 +1,74 @@
+<div>
+  <h3><%= l(:label_trakers_permissions) %></h3>
+  <div class="autoscroll">
+    <table class="list permissions">
+      <thead>
+        <tr>
+        <th><%=l(:label_tracker_all)%></th>
+        <% @roles.each do |role| %>
+        <th>
+            <%= content_tag(role.builtin? ? 'em' : 'span', role.name) %>
+        </th>
+        <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% permissions = [:view_issues, :add_issues, :edit_issues, :add_issue_notes, :delete_issues] %>
+        <% permissions.each do |permission| %>
+          <tr class="all-trackers-<%= permission%>">
+            <td class="name">
+                <%= link_to_function('',
+                                     "toggleCheckboxesBySelector('tr.all-trackers-#{permission} input[type=checkbox]')",
+                                     :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}",
+                                     :class => 'icon-only icon-checked') %>
+                <%= l("permission_#{permission}") %>
+            </td>
+            <% @roles.each do |role| %>
+              <% if role.setable_permissions.collect(&:name).include? permission %>
+                <td title="<%= l("permission_#{permission}") + "(#{role.name})" %>">
+                  <%= hidden_field_tag "permissions_all_trackers[#{role.id}][#{permission}]", '0', :id => nil %>
+                  <%= check_box_tag "permissions_all_trackers[#{role.id}][#{permission}]", '1', (role.permissions_all_trackers?(permission)), :id => nil, class:"view_issues-#{role.id}_shown", :data => {:disables => ".#{permission}_tracker_role_#{role.id}"} %>
+                </td>
+                <% else %>
+                <td></td>
+              <% end %>
+              <%= hidden_field_tag "permissions_tracker_ids[#{role.id}][#{permission}][]", '' %>
+            <% end %>
+          </tr>
+        <% end %>
+        <% Tracker.sorted.all.each do |tracker| %>
+        <tr class="group open">
+          <td>
+            <span class="expander icon icon-expended" onclick="toggleRowGroup(this);">&nbsp;</span>
+            <%= tracker.name %>
+          </td>
+          <% @roles.each do |role| %>
+            <td class="role"><%= role.name %></td>
+          <% end %>
+        </tr>
+          <% permissions.each do |permission| %>
+            <tr class="permission-<%= permission%><%= tracker.id%>">
+              <td class="name">
+                  <%= link_to_function('',
+                                       "toggleCheckboxesBySelector('.permission-#{permission}#{tracker.id} input:enabled')",
+                                       :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}",
+                                       :class => 'icon-only icon-checked') %>
+                  <%= l("permission_#{permission}") %>
+              </td>
+              <% @roles.each do |role| %>
+                <% if role.setable_permissions.collect(&:name).include? permission %>
+                  <td title="<%= l("permission_#{permission}") + "(#{role.name})" %>">
+                    <%= check_box_tag "permissions_tracker_ids[#{role.id}][#{permission}][]", tracker.id, (role.permissions_tracker_ids[permission].include? tracker.id.to_s), :id => "role_permissions_tracker_ids-#{role.id}_#{tracker.id}", :class => "#{permission}_tracker_role_#{role.id} view_issues-#{role.id}_shown" %>
+
+                  </td>
+                  <% else %>
+                  <td></td>
+                <% end %>
+              <% end %>
+            </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/roles/_trackers_permissions.html.erb
+++ b/app/views/roles/_trackers_permissions.html.erb
@@ -1,7 +1,7 @@
 <div>
   <h3><%= l(:label_trakers_permissions) %></h3>
   <div class="autoscroll">
-    <table class="list permissions">
+    <table class="list trakers_permissions">
       <thead>
         <tr>
         <th><%=l(:label_tracker_all)%></th>
@@ -57,11 +57,16 @@
               </td>
               <% @roles.each do |role| %>
                 <% if role.setable_permissions.collect(&:name).include? permission %>
-                  <td title="<%= l("permission_#{permission}") + "(#{role.name})" %>">
-                    <%= check_box_tag "permissions_tracker_ids[#{role.id}][#{permission}][]", tracker.id, (role.permissions_tracker_ids[permission].include? tracker.id.to_s), :id => "role_permissions_tracker_ids-#{role.id}_#{tracker.id}", :class => "#{permission}_tracker_role_#{role.id} view_issues-#{role.id}_shown" %>
+                 <!--   This condition is because there are (redmine tests) that call the function without passing this parameter -->
+                  <% if  role.permissions_tracker_ids.present? %>
+                    <td title="<%= l("permission_#{permission}") + "(#{role.name})" %>">
+                      <%= check_box_tag "permissions_tracker_ids[#{role.id}][#{permission}][]", tracker.id, (role.permissions_tracker_ids[permission].include? tracker.id.to_s), :id => "role_permissions_tracker_ids-#{role.id}_#{tracker.id}", :class => "#{permission}_tracker_role_#{role.id} view_issues-#{role.id}_shown" %>
 
-                  </td>
+                    </td>
                   <% else %>
+                    <td></td>
+                  <% end %>
+                <% else %>
                   <td></td>
                 <% end %>
               <% end %>

--- a/assets/javascripts/redmine_tiny_features.js
+++ b/assets/javascripts/redmine_tiny_features.js
@@ -1,0 +1,31 @@
+$(document).ready(function(){
+
+  addDataShowsForPermission();
+
+  $('#content').on('change', 'input[data-disables], input[data-enables], input[data-shows]', toggleVisibilityOnChange);
+  toggleVisibilityInit();
+
+  function toggleVisibilityOnChange() {
+    var checked = $(this).is(':checked');
+    if(!checked) {
+      $($(this).data('shows')).css('visibility', 'hidden');
+    }
+    else {
+      $($(this).data('shows')).css('visibility', 'visible');
+    }
+
+  }
+
+  function addDataShowsForPermission() {
+    $('[class^="role-"]').each(function(){
+      //get roleId after delete role-
+      roleid = $(this).attr('class').substring(5);
+      st = "." + $(this).attr('value') + "-" + roleid + "_shown";
+      $(this).attr('data-shows', st);
+    });
+  }
+
+  function toggleVisibilityInit() {
+    $('input[data-disables], input[data-enables], input[data-shows]').each(toggleVisibilityOnChange);
+  }
+});

--- a/assets/stylesheets/tiny_features.css
+++ b/assets/stylesheets/tiny_features.css
@@ -10,3 +10,5 @@
 .warning-issue-closed p { text-align:center; margin:0; padding:7px 10px; }
 .warning-issue-closed p.buttons { text-align:right; font-size:110%; }
 .warning-issue-closed p a { color:#fff; font-weight:bold; }
+
+table.list th:first-child {min-width: 30%;}

--- a/assets/stylesheets/tiny_features.css
+++ b/assets/stylesheets/tiny_features.css
@@ -12,3 +12,5 @@
 .warning-issue-closed p a { color:#fff; font-weight:bold; }
 
 table.list th:first-child {min-width: 30%;}
+table.trakers_permissions td.role {color:#999;font-size:90%;font-weight:normal !important;text-align:center;vertical-align:bottom;}
+table.trakers_permissions tr.group>td:nth-of-type(1),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,3 +13,5 @@ en:
   no_key_value_custom_field: This project do not use any custom field with key/value format.
   permission_manage_project_enumerations: Manager custom fields possible values per project
   default_project: Default project for new issues
+  label_general_data: General data
+  label_trakers_permissions: Tracker permissions

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -13,3 +13,5 @@ fr:
   no_key_value_custom_field: Ce projet n'utilise aucun champ personnalisé de type clé/valeur.
   permission_manage_project_enumerations: Gérer les valeurs possibles des champs personnalisés par projet
   default_project: Projet par défaut pour les nouvelles demandes
+  label_general_data: Données générales
+  label_trakers_permissions: Permissions des trackers

--- a/init.rb
+++ b/init.rb
@@ -7,6 +7,7 @@ Rails.application.config.to_prepare do
   require_dependency 'redmine_tiny_features/projects_helper_patch'
   require_dependency 'redmine_tiny_features/queries_helper_patch'
   require_dependency 'redmine_tiny_features/issues_controller_patch'
+  require_dependency 'redmine_tiny_features/roles_controller_patch'
 end
 
 Redmine::Plugin.register :redmine_tiny_features do

--- a/lib/redmine_tiny_features/hooks.rb
+++ b/lib/redmine_tiny_features/hooks.rb
@@ -2,7 +2,8 @@ module RedmineTinyFeatures
   class Hooks < Redmine::Hook::ViewListener
     #adds our css on each page
     def view_layouts_base_html_head(context)
-      stylesheet_link_tag("tiny_features", :plugin => "redmine_tiny_features")
+      stylesheet_link_tag("tiny_features", :plugin => "redmine_tiny_features")+
+      javascript_include_tag('redmine_tiny_features.js', plugin: 'redmine_tiny_features')
     end
   end
 end

--- a/lib/redmine_tiny_features/roles_controller_patch.rb
+++ b/lib/redmine_tiny_features/roles_controller_patch.rb
@@ -1,0 +1,32 @@
+require_dependency 'roles_controller'
+
+class RolesController
+
+  def update_permissions
+    @roles = Role.where(:id => params[:permissions].keys)
+    @roles.each do |role|
+
+      role.permissions = params[:permissions][role.id.to_s]
+      if params[:assignable].present?
+        role.assignable =  params[:assignable][role.id.to_s].present? ? true : false
+      else
+        role.assignable = false
+      end
+
+      role.issues_visibility = params[:issues_visibility][role.id.to_s] if params[:issues_visibility][role.id.to_s].present?
+      # update permissions of trackers
+      params[:permissions_tracker_ids][role.id.to_s].each do |permission|
+        role.set_permission_trackers(permission.first, permission.second)
+      end
+
+      params[:permissions_all_trackers][role.id.to_s].each do |permission|
+        role.set_permission_trackers(permission.first, :all) if permission.second == "1"
+      end
+
+      role.save
+    end
+    flash[:notice] = l(:notice_successful_update)
+    redirect_to roles_path
+  end
+
+end

--- a/lib/redmine_tiny_features/roles_controller_patch.rb
+++ b/lib/redmine_tiny_features/roles_controller_patch.rb
@@ -13,16 +13,22 @@ class RolesController
         role.assignable = false
       end
 
-      role.issues_visibility = params[:issues_visibility][role.id.to_s] if params[:issues_visibility][role.id.to_s].present?
+      if params[:issues_visibility].present? # This condition is because there are (redmine tests) that call the function without passing this parameter
+        role.issues_visibility = params[:issues_visibility][role.id.to_s] if params[:issues_visibility][role.id.to_s].present?
+      end
+
       # update permissions of trackers
-      params[:permissions_tracker_ids][role.id.to_s].each do |permission|
-        role.set_permission_trackers(permission.first, permission.second)
+      if params[:permissions_tracker_ids].present? # This condition is because there are (redmine tests) that call the function without passing this parameter
+        params[:permissions_tracker_ids][role.id.to_s].each do |permission|
+          role.set_permission_trackers(permission.first, permission.second)
+        end
       end
 
-      params[:permissions_all_trackers][role.id.to_s].each do |permission|
-        role.set_permission_trackers(permission.first, :all) if permission.second == "1"
+      if params[:permissions_all_trackers].present? # This condition is because there are (redmine tests) that call the function without passing this parameter
+        params[:permissions_all_trackers][role.id.to_s].each do |permission|
+          role.set_permission_trackers(permission.first, :all) if permission.second == "1"
+        end
       end
-
       role.save
     end
     flash[:notice] = l(:notice_successful_update)

--- a/spec/system/permissions_spec.rb
+++ b/spec/system/permissions_spec.rb
@@ -1,0 +1,116 @@
+require "spec_helper"
+require "active_support/testing/assertions"
+
+RSpec.describe "Synthesis of roles", type: :system do
+  fixtures :roles, :users
+
+  before do
+    log_user('admin', 'admin')
+    # settings by default for all roles
+    roles.each do |role|
+      role.permissions_all_trackers = { "view_issues" => "1", "add_issues" => "1", "edit_issues" => "1", "add_issue_notes" => "1", "delete_issues"=> "1" }
+      role.permissions_tracker_ids = { "view_issues" => [], "add_issues" => [], "edit_issues" => [], "add_issue_notes" => [], "delete_issues" => [] }
+      role.save
+    end
+  end
+
+  it "Should contain general data" do
+    visit 'roles/permissions'
+
+    page.assert_selector('tr.assignable', count: 1)
+
+    # for all the roles except Non members or Anonymous
+    page.assert_selector("input[name^='assignable['", count: 3)
+
+    # for every option of ROLE::ISSUES_VISIBILITY_OPTIONS
+    Role::ISSUES_VISIBILITY_OPTIONS.each do |option|
+      # ex: <tr class="visibility_all">
+      str = 'tr.visibility_' + option.first
+      page.assert_selector(str, count: 1)
+    end
+
+    # for all the roles except Anonymous
+    roles.each do |role|
+      Role::ISSUES_VISIBILITY_OPTIONS.each do |option|
+        unless role.anonymous?
+          # ex:<input type="radio" id="issues_visibility_1_all" name="issues_visibility[1]"  value="all">
+          str = "input[id='issues_visibility_"+ role.id.to_s + '_' + option.first + "'][name='issues_visibility[" + role.id.to_s + "]'][value='"+ option.first + "']"
+          page.assert_selector(str, count: 1)
+        end
+      end
+    end
+  end
+
+  it "Should contain permissions of trackers" do
+    visit 'roles/permissions'
+    permissions = [:view_issues, :add_issues, :edit_issues, :add_issue_notes, :delete_issues]
+
+    # permissions for all trackers
+    permissions.each do |permission|
+      # ex: <tr class="all-trackers-view_issues">
+      str =  'tr.all-trackers-' + permission.to_s
+      page.assert_selector(str, count: 1)
+    end
+
+    # permissions for every tracker
+    Tracker.sorted.all.each do |tracker|
+      permissions.each do |permission|
+        # ex:<tr class="permission-add_issues2">
+        str = 'tr.permission-' + permission.to_s + tracker.id.to_s
+        page.assert_selector(str, count: 1)
+        roles.each do |role|
+          if role.setable_permissions.collect(&:name).include? permission
+            # ex: <input class="add_issues_tracker_role_2" >
+            str = 'input.'+ permission.to_s + '_tracker_role_' + role.id.to_s
+            page.assert_selector(str, count: Tracker.count)
+            expect(page).to have_css(str + '[disabled]')
+            # ex: <input  name="permissions_tracker_ids[1][add_issues][]" value="1">
+            str = "input[name='permissions_tracker_ids[" + role.id.to_s + "][" + permission.to_s + "][]'][value='"+ tracker.id.to_s + "']"
+            page.assert_selector(str, count: 1)
+          end
+        end
+      end
+    end
+  end
+
+  it "Should enable the permission for every tracker when uncheck it in (all tracker)" do
+    visit 'roles/permissions'
+    find("input[name='permissions_all_trackers[1][view_issues]']").click
+    Tracker.sorted.all.each do |tracker|
+      str = "input[name='permissions_tracker_ids[1][view_issues][]'][value='"+ tracker.id.to_s + "']"
+      expect(page).to_not have_css(str + '[disabled]')
+    end
+  end
+
+  it "Should hide (issues_visibility options/general data) and permission of trackers when we uncheck (View Issues) of a role" do
+    visit 'roles/permissions'
+    #find('.view_issues-1_shown').should be_visible
+    expect(page).to have_css('.view_issues-1_shown', visible: :visible)
+    find("input[name='permissions[1][]'][value='view_issues']").click
+    expect(page).to have_css('.view_issues-1_shown', visible: :hidden)
+  end
+
+  it "Should uncheck permissions_all_trackers for all the roles/test function(toggleCheckboxesBySelector)" do
+    visit 'roles/permissions'
+
+    find("tr.all-trackers-add_issues a" ).click
+    expect(find("input[name='permissions_all_trackers[1][add_issues]']").checked?).to be(false)
+    expect(find("input[name='permissions_all_trackers[2][add_issues]']").checked?).to be(false)
+    expect(find("input[name='permissions_all_trackers[3][add_issues]']").checked?).to be(false)
+    expect(find("input[name='permissions_all_trackers[4][add_issues]']").checked?).to be(false)
+    expect(find("input[name='permissions_all_trackers[5][add_issues]']").checked?).to be(false)
+  end
+
+  it "Should change the setting from permissions_all_trackers to permissions_tracker_ids " do
+    visit 'roles/permissions'
+
+    find('input[data-disables=".view_issues_tracker_role_1"]').click
+    find("input[name='permissions_tracker_ids[1][view_issues][]'][id='role_permissions_tracker_ids-1_1']").click
+    find("input[name='permissions_tracker_ids[1][view_issues][]'][id='role_permissions_tracker_ids-1_3']").click
+    # click on button save
+    find("input[name='commit']").click
+
+    expect(Role.find(1).permissions_all_trackers["view_issues"]).to eq "0"
+    expect(Role.find(1).permissions_tracker_ids["view_issues"]).to eq ["1", "3"]
+  end
+end

--- a/spec/views/roles/permissions.html.erb_spec.rb
+++ b/spec/views/roles/permissions.html.erb_spec.rb
@@ -4,14 +4,19 @@ describe "roles/permissions.html.erb", type: :view do
 	fixtures :roles, :users
 
 	it "Should contain two links check all and uncheck everything in the role filtering block" do
-    	User.current = User.find(1)
-    	assign(:roles, roles)
-    	assign(:permissions, Redmine::AccessControl.permissions.select { |p| !p.public? })
+  	User.current = User.find(1)
+  	assign(:roles, roles)
+  	assign(:permissions, Redmine::AccessControl.permissions.select { |p| !p.public? })
+  	#set settings by default for all roles
+  	roles.each do |role|
+  		role.permissions_all_trackers = { "view_issues"=>"1", "add_issues"=>"1", "edit_issues"=>"1", "add_issue_notes"=>"1", "delete_issues"=>"1" }
+  		role.permissions_tracker_ids = { "view_issues"=>[], "add_issues"=>[], "edit_issues"=>[], "add_issue_notes"=>[], "delete_issues"=>[] }
+  		role.save
+  	end
+  	render
 
-    	render
-
-    	assert_select "form#roles-form"
-    	assert_select 'a[href=?][onclick=?]', '#', "checkAll('roles-form', true); return false;"
-    	assert_select 'a[href=?][onclick=?]', '#', "checkAll('roles-form', false); return false;"
-    end  	
+  	assert_select "form#roles-form"
+  	assert_select 'a[href=?][onclick=?]', '#', "checkAll('roles-form', true); return false;"
+  	assert_select 'a[href=?][onclick=?]', '#', "checkAll('roles-form', false); return false;"
+  end
 end


### PR DESCRIPTION
Amélioration de la synthèse des rôles : 
  - checkbox : demandes assignables aux utilisateurs ayant ce rôle
  - boutons radios : visibilités des demandes
  - Permissions sur tous les trackers
  - Permissions pour chaque tracker

Une catégorie spécifique a été mise en place pour les trackers.

Pour être cohérent avec le fonctionnement du coeur : lorsque le bouton "Voir les demandes" n'est pas cochée, la partie correspondante est masquée.

Ajout des tests fonctionnels.
