### PR TITLE
Ticket 90447 - Correction affichage lorsqu'il y a beaucoup de rôles

### DIFF
--- a/app/views/roles/_general_data.html.erb
+++ b/app/views/roles/_general_data.html.erb
@@ -1,10 +1,11 @@
-<div class="autoscroll">
+<p><h3><%=l(:label_general_data_permission)%></h3></p>
 <table class="list permmision">
   <thead>
       <tr>
       <th class="col-permmision"><%=l(:label_general_data)%></th>
       <% @roles.each do |role| %>
       <th>
+          <%= content_tag('span', '', :class => 'trakers-permissions') %>
           <%= content_tag(role.builtin? ? 'em' : 'span', role.name) %>
       </th>
       <% end %>
@@ -61,4 +62,4 @@
     <% end %>
   </tbody>
 </table>
-</div>
+<p><h3><%=l(:label_permissions)%></h3></p>

--- a/app/views/roles/_trackers_permissions.html.erb
+++ b/app/views/roles/_trackers_permissions.html.erb
@@ -1,79 +1,77 @@
-<div>
-  <h3><%= l(:label_trakers_permissions) %></h3>
-  <div class="autoscroll">
-    <table class="list trakers_permissions">
-      <thead>
-        <tr>
-        <th><%=l(:label_tracker_all)%></th>
+<p><h3><%=l(:label_trakers_permissions)%></h3></p>
+</table>
+<table class="list trakers_permissions">
+  <thead>
+    <tr>
+    <th><%=l(:label_tracker_all)%></th>
+    <% @roles.each do |role| %>
+    <th>
+        <%= content_tag('span', '', :class => 'trakers-permissions') %>
+        <%= content_tag(role.builtin? ? 'em' : 'span', role.name) %>
+    </th>
+    <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <% permissions = [:view_issues, :add_issues, :edit_issues, :add_issue_notes, :delete_issues] %>
+    <% permissions.each do |permission| %>
+      <tr class="all-trackers-<%= permission%>">
+        <td class="name">
+            <%= link_to_function('',
+                                 "toggleCheckboxesBySelector('tr.all-trackers-#{permission} input[type=checkbox]')",
+                                 :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}",
+                                 :class => 'icon-only icon-checked') %>
+            <%= l("permission_#{permission}") %>
+        </td>
         <% @roles.each do |role| %>
-        <th>
-            <%= content_tag(role.builtin? ? 'em' : 'span', role.name) %>
-        </th>
-        <% end %>
-        </tr>
-      </thead>
-      <tbody>
-        <% permissions = [:view_issues, :add_issues, :edit_issues, :add_issue_notes, :delete_issues] %>
-        <% permissions.each do |permission| %>
-          <tr class="all-trackers-<%= permission%>">
-            <td class="name">
-                <%= link_to_function('',
-                                     "toggleCheckboxesBySelector('tr.all-trackers-#{permission} input[type=checkbox]')",
-                                     :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}",
-                                     :class => 'icon-only icon-checked') %>
-                <%= l("permission_#{permission}") %>
+          <% if role.setable_permissions.collect(&:name).include? permission %>
+            <td title="<%= l("permission_#{permission}") + "(#{role.name})" %>">
+              <%= hidden_field_tag "permissions_all_trackers[#{role.id}][#{permission}]", '0', :id => nil %>
+              <%= check_box_tag "permissions_all_trackers[#{role.id}][#{permission}]", '1', (role.permissions_all_trackers?(permission)), :id => nil, class:"view_issues-#{role.id}_shown", :data => {:disables => ".#{permission}_tracker_role_#{role.id}"} %>
             </td>
-            <% @roles.each do |role| %>
-              <% if role.setable_permissions.collect(&:name).include? permission %>
-                <td title="<%= l("permission_#{permission}") + "(#{role.name})" %>">
-                  <%= hidden_field_tag "permissions_all_trackers[#{role.id}][#{permission}]", '0', :id => nil %>
-                  <%= check_box_tag "permissions_all_trackers[#{role.id}][#{permission}]", '1', (role.permissions_all_trackers?(permission)), :id => nil, class:"view_issues-#{role.id}_shown", :data => {:disables => ".#{permission}_tracker_role_#{role.id}"} %>
-                </td>
-                <% else %>
-                <td></td>
-              <% end %>
-              <%= hidden_field_tag "permissions_tracker_ids[#{role.id}][#{permission}][]", '' %>
-            <% end %>
-          </tr>
+            <% else %>
+            <td></td>
+          <% end %>
+          <%= hidden_field_tag "permissions_tracker_ids[#{role.id}][#{permission}][]", '' %>
         <% end %>
-        <% Tracker.sorted.all.each do |tracker| %>
-        <tr class="group open">
-          <td>
-            <span class="expander icon icon-expended" onclick="toggleRowGroup(this);">&nbsp;</span>
-            <%= tracker.name %>
+      </tr>
+    <% end %>
+    <% Tracker.sorted.all.each do |tracker| %>
+    <tr class="group open">
+      <td>
+        <span class="expander icon icon-expended" onclick="toggleRowGroup(this);">&nbsp;</span>
+        <%= tracker.name %>
+      </td>
+      <% @roles.each do |role| %>
+        <td class="role"><%= role.name %></td>
+      <% end %>
+    </tr>
+      <% permissions.each do |permission| %>
+        <tr class="permission-<%= permission%><%= tracker.id%>">
+          <td class="name">
+              <%= link_to_function('',
+                                   "toggleCheckboxesBySelector('.permission-#{permission}#{tracker.id} input:enabled')",
+                                   :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}",
+                                   :class => 'icon-only icon-checked') %>
+              <%= l("permission_#{permission}") %>
           </td>
           <% @roles.each do |role| %>
-            <td class="role"><%= role.name %></td>
+            <% if role.setable_permissions.collect(&:name).include? permission %>
+             <!--   This condition is because there are (redmine tests) that call the function without passing this parameter -->
+              <% if  role.permissions_tracker_ids.present? %>
+                <td title="<%= l("permission_#{permission}") + "(#{role.name})" %>">
+                  <%= check_box_tag "permissions_tracker_ids[#{role.id}][#{permission}][]", tracker.id, (role.permissions_tracker_ids[permission].include? tracker.id.to_s), :id => "role_permissions_tracker_ids-#{role.id}_#{tracker.id}", :class => "#{permission}_tracker_role_#{role.id} view_issues-#{role.id}_shown" %>
+
+                </td>
+              <% else %>
+                <td></td>
+              <% end %>
+            <% else %>
+              <td></td>
+            <% end %>
           <% end %>
         </tr>
-          <% permissions.each do |permission| %>
-            <tr class="permission-<%= permission%><%= tracker.id%>">
-              <td class="name">
-                  <%= link_to_function('',
-                                       "toggleCheckboxesBySelector('.permission-#{permission}#{tracker.id} input:enabled')",
-                                       :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}",
-                                       :class => 'icon-only icon-checked') %>
-                  <%= l("permission_#{permission}") %>
-              </td>
-              <% @roles.each do |role| %>
-                <% if role.setable_permissions.collect(&:name).include? permission %>
-                 <!--   This condition is because there are (redmine tests) that call the function without passing this parameter -->
-                  <% if  role.permissions_tracker_ids.present? %>
-                    <td title="<%= l("permission_#{permission}") + "(#{role.name})" %>">
-                      <%= check_box_tag "permissions_tracker_ids[#{role.id}][#{permission}][]", tracker.id, (role.permissions_tracker_ids[permission].include? tracker.id.to_s), :id => "role_permissions_tracker_ids-#{role.id}_#{tracker.id}", :class => "#{permission}_tracker_role_#{role.id} view_issues-#{role.id}_shown" %>
-
-                    </td>
-                  <% else %>
-                    <td></td>
-                  <% end %>
-                <% else %>
-                  <td></td>
-                <% end %>
-              <% end %>
-            </tr>
-          <% end %>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>

--- a/assets/stylesheets/tiny_features.css
+++ b/assets/stylesheets/tiny_features.css
@@ -14,3 +14,8 @@
 table.list th:first-child {min-width: 30%;}
 table.trakers_permissions td.role {color:#999;font-size:90%;font-weight:normal !important;text-align:center;vertical-align:bottom;}
 table.trakers_permissions tr.group>td:nth-of-type(1),
+
+.trakers-permissions {
+  padding-left: 16px;
+  display: inline-block;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,3 +15,4 @@ en:
   default_project: Default project for new issues
   label_general_data: General data
   label_trakers_permissions: Tracker permissions
+  label_general_data_permission: General data permissions

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -15,3 +15,4 @@ fr:
   default_project: Projet par défaut pour les nouvelles demandes
   label_general_data: Données générales
   label_trakers_permissions: Permissions des trackers
+  label_general_data_permission: Permissions des données générales


### PR DESCRIPTION
Correction de l'affichage lorsqu'il y a beaucoup de rôles : 
  - Séparation des blocs
  - Tests de correction de l'affichage : OK