### PR TITLE
Mettre à jour la table disabled_custom_field_enumerations 

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -16,6 +16,8 @@ Rails.application.config.to_prepare do
   require_dependency 'redmine_tiny_features/issues_helper_patch'
   require_dependency 'redmine_tiny_features/journal_patch'
   require_dependency 'redmine_tiny_features/mailer_patch'
+  require_dependency 'redmine_tiny_features/custom_field_enumeration_patch'
+  require_dependency 'redmine_tiny_features/custom_field_patch'
 end
 
 Redmine::Plugin.register :redmine_tiny_features do

--- a/lib/redmine_tiny_features/custom_field_enumeration_patch.rb
+++ b/lib/redmine_tiny_features/custom_field_enumeration_patch.rb
@@ -1,0 +1,5 @@
+require_dependency 'custom_field_enumeration'
+
+class CustomFieldEnumeration < ActiveRecord::Base
+	has_many :disabled_custom_field_enumerations,  :dependent => :delete_all
+end

--- a/lib/redmine_tiny_features/custom_field_patch.rb
+++ b/lib/redmine_tiny_features/custom_field_patch.rb
@@ -1,0 +1,8 @@
+require_dependency 'custom_field'
+
+class CustomField < ActiveRecord::Base
+	##### PATCH ,to call the destroy method of (CustomFieldEnumeration has :dependent => :delete_all)
+	has_many :enumerations, lambda {order(:position)},
+			:class_name => 'CustomFieldEnumeration',
+			:dependent => :destroy
+end

--- a/lib/redmine_tiny_features/project_patch.rb
+++ b/lib/redmine_tiny_features/project_patch.rb
@@ -2,6 +2,6 @@ require_dependency 'project'
 
 class Project < ActiveRecord::Base
 
-  has_many :disabled_custom_field_enumerations
+  has_many :disabled_custom_field_enumerations,  :dependent => :delete_all
 
 end

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -40,5 +40,33 @@ describe "CustomField" do
       assert f.valid_field_value?(123)
     end
 
+    describe "Update the table disabled_custom_field_enumerations in case of cascade deleting" do
+      let(:project) { Project.find(1) }
+      let(:field) { CustomField.create(:name => 'Test', :field_format => 'enumeration') }
+      let(:c_f_e1) { CustomFieldEnumeration.create(name: 'val1', position: 1, active: true, custom_field_id: field.id) }
+      let(:c_f_e2) { CustomFieldEnumeration.create(name: 'val2', position: 2, active: true, custom_field_id: field.id) }
+
+      before do
+        CustomFieldEnumeration.create(name: 'val3', position: 3, active: true, custom_field_id: field.id)
+        DisabledCustomFieldEnumeration.create(project: project, custom_field_enumeration_id: c_f_e1.id)
+        DisabledCustomFieldEnumeration.create(project: project, custom_field_enumeration_id: c_f_e2.id)
+        expect(DisabledCustomFieldEnumeration.count).to eq(2)
+      end
+
+      it "Should update the table disabled_custom_field_enumerations when deleting a project" do
+        project.destroy
+        expect(DisabledCustomFieldEnumeration.count).to eq(0)
+      end
+
+      it "Should update the table disabled_custom_field_enumerations when deleting a customField" do
+        field.destroy
+        expect(DisabledCustomFieldEnumeration.count).to eq(0)
+      end
+
+      it "Should update the table disabled_custom_field_enumerations when deleting a CustomFieldEnumeration" do
+        c_f_e1.destroy
+        expect(DisabledCustomFieldEnumeration.count).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
Mettre à jour la table disabled_custom_field_enumerations en cas de suppression en cascade
-  suppression d'un projet
- suppression d'une valeur 
- suppression du champ personnalisé 