### PR TITLE
Pouvoir filtrer les projets par modules activés

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,3 +25,4 @@ en:
   label_range: "Range"
   label_min_max_range: "Min / Max values"
   label_steps: "Step"
+  field_module_enabled: "Enabled modules"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -25,3 +25,4 @@ fr:
   label_range: "Intervalle"
   label_min_max_range: "Valeurs minimale et maximale"
   label_steps: "Incrément"
+  field_module_enabled: "Modules activés"

--- a/init.rb
+++ b/init.rb
@@ -19,6 +19,7 @@ Rails.application.config.to_prepare do
   require_dependency 'redmine_tiny_features/custom_field_enumeration_patch'
   require_dependency 'redmine_tiny_features/custom_field_patch'
   require_dependency 'redmine_tiny_features/issue_custom_field_patch'
+  require_dependency 'redmine_tiny_features/project_query_patch'
 end
 
 Redmine::Plugin.register :redmine_tiny_features do

--- a/lib/redmine_tiny_features/project_patch.rb
+++ b/lib/redmine_tiny_features/project_patch.rb
@@ -4,6 +4,10 @@ class Project < ActiveRecord::Base
 
   has_many :disabled_custom_field_enumerations, :dependent => :delete_all
 
+  def module_enabled    
+    EnabledModule.where("project_id = ? ", self.id).map { |e_m| l("project_module_#{e_m.name}") }
+  end
+
 end
 
 module RedmineTinyFeatures
@@ -22,10 +26,10 @@ module RedmineTinyFeatures
         base_statement = "1=1"
       else
         base_statement = if perm && perm.read?
-                           "#{Project.table_name}.status <> #{Project::STATUS_ARCHIVED}"
-                         else
-                           "#{Project.table_name}.status = #{Project::STATUS_ACTIVE}"
-                         end
+                            "#{Project.table_name}.status <> #{Project::STATUS_ARCHIVED}"
+                          else
+                            "#{Project.table_name}.status = #{Project::STATUS_ACTIVE}"
+                          end
         if perm && perm.project_module
           # If the permission belongs to a project module, make sure the module is enabled
           base_statement +=

--- a/lib/redmine_tiny_features/project_query_patch.rb
+++ b/lib/redmine_tiny_features/project_query_patch.rb
@@ -1,0 +1,38 @@
+require_dependency 'query'
+require_dependency 'project_query'
+
+class ProjectQuery < Query
+  self.available_columns << QueryColumn.new(:module_enabled, :sortable => false, :default_order => 'asc')
+end
+
+module PluginRedmineTinyFeatures
+  module ProjectQueryPatch
+
+    def initialize_available_filters
+      super
+
+      module_values = EnabledModule.all.collect { |s| [l("project_module_#{s.name}"), s.name] }.sort_by { |v| v.first }.uniq
+      add_available_filter("module_enabled", :type => :list_subprojects, :values => module_values)
+    end
+
+    def sql_for_module_enabled_field(field, operator, value)
+      case operator
+      when "!*", "*"
+        module_enabled_table = EnabledModule.table_name
+        project_table = Project.table_name
+        #return only the projects for which a particular module or module group is activated
+        "#{project_table}.id  #{ operator == '*' ? 'IN' : 'NOT IN' } (SELECT #{module_enabled_table}.project_id FROM #{module_enabled_table} " +
+          "JOIN #{project_table} ON #{module_enabled_table}.project_id = #{project_table}.id " + ') '
+      when "=", "!"        
+        module_enabled_table = EnabledModule.table_name
+        project_table = Project.table_name       
+        #return only the projects for which a particular module or module group is activated
+        "#{project_table}.id #{ operator == '=' ? 'IN' : 'NOT IN' } (SELECT #{module_enabled_table}.project_id FROM #{module_enabled_table} " +
+          "JOIN #{project_table} ON #{module_enabled_table}.project_id = #{project_table}.id AND " +
+          sql_for_field('name', '=', value, module_enabled_table, 'name') + ') '
+      end
+    end     
+  end
+end
+
+ProjectQuery.prepend PluginRedmineTinyFeatures::ProjectQueryPatch

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+require "active_support/testing/assertions"
+
+describe ProjectsController, type: :controller do
+  include ActiveSupport::Testing::Assertions
+
+  render_views
+
+  fixtures :users, :projects, :enabled_modules
+
+  before do
+    @request.session[:user_id] = 1 #=> admin ; permissions are hard...
+  end
+
+  context "Add a filter on the projects page: module activated" do
+
+    it "should query use module_enabled when index with column module_enabled" do
+      columns = ['name', 'module_enabled']
+      get :index, params: { :set_filter => 1, :c => columns }
+      expect(response).to be_successful
+      # query should use specified columns
+      query = assigns(:query)
+      
+      assert_kind_of ProjectQuery, query
+      expect(query.column_names.map(&:to_s)).to eq columns
+    end
+
+    it "should ensure that the changes are compatible with the CSV" do
+      module_test = "issue_tracking"
+      columns = ['name', 'module_enabled']
+
+      get :index, params: { :set_filter => 1,
+                            :f => ["module_enabled"],
+                            :op => { "module_enabled" => "=" },
+                            :v => { "module_enabled" => [module_test] },
+                            :c => columns,
+                            :format => 'csv' }
+
+      expect(response).to be_successful
+      expect(response.media_type).to eq 'text/csv'
+
+      lines = response.body.chomp.split("\n")
+
+      expect(lines[0].split(',')[1]).to eq "Enabled modules"
+
+      # projects for which the module Issue tracking is enabled
+      ids = EnabledModule.where(name: module_test).map{ |e_m| e_m.project_id }
+      # except the first line ( names of columns )
+      expect(lines.count - 1).to eq(ids.count)
+      
+      project_csv = []
+
+      lines.count.times do |count|
+        project_csv.push( lines[count].split(',')[0]) if count > 0
+        expect(lines[count].split(',').to_s).to include("Issue tracking") if count > 0
+      end
+      
+      expect(project_csv.sort).to eq(Project.where(id: ids).map(&:name).sort)
+    end
+  end
+end  

--- a/spec/models/project_query_spec.rb
+++ b/spec/models/project_query_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe "ProjectQuery" do
+  fixtures :users, :projects, :enabled_modules
+
+  before do
+    User.current = User.find(1)
+  end
+
+  def find_projects_with_query(query)
+    Project.where(
+      query.statement
+    ).all
+  end
+
+  it "should ProjectQuery have available_filters module_enabled" do
+    query = ProjectQuery.new
+    expect(query.available_filters).to include 'module_enabled'
+  end
+
+  describe "should filter projects with module_enabled" do
+    let!(:module_test) { "wiki" }
+
+    it "operator equal =" do
+      # projects for which the module wiki is enabled
+      ids = EnabledModule.where(name: module_test).map{|e_m| e_m.project_id }
+      query = ProjectQuery.new(:name => '_', :filters => { 'module_enabled' => { :operator => '=', :values => [module_test] } })
+      result = find_projects_with_query(query)
+
+      expect(result.count).to eq (ids.count)
+      expect(result.to_a).to eq(Project.where(id: ids))
+    end
+
+    it "operator not equal !" do
+      ids = EnabledModule.where(name: module_test).map{|e_m| e_m.project_id }
+      query = ProjectQuery.new(:name => '_', :filters => { 'module_enabled' => { :operator => '!', :values => [module_test] } })
+      result = find_projects_with_query(query)
+      
+      expect(result.count).to eq ((Project.count - ids.count))
+      expect(result.to_a).not_to eq(Project.where(id: ids))
+    end
+
+    it "operator all *" do
+      query = ProjectQuery.new(:name => '_', :filters => { 'module_enabled' => { :operator => '*', :values => [''] } })
+      result = find_projects_with_query(query)
+
+      expect(result.count).to eq (EnabledModule.all.map{ |e_m| e_m.project_id }.uniq.count)
+    end
+
+    it "operator any !*" do
+      query = ProjectQuery.new(:name => '_', :filters => { 'module_enabled' => { :operator => '!*', :values => [''] } })
+      result = find_projects_with_query(query)
+
+      expect(result.count).to eq ((Project.all.map(&:id).uniq - EnabledModule.all.map{ |e_m| e_m.project_id }.uniq).count)
+    end
+  end
+end


### PR DESCRIPTION
- Implémenter les méthodes initialize_available_filters + sql_for_module_enabled_field dans ProjectQueryPatch
- test

