### PR TITLE
Empêcher la copie des tickets de mise en production#203683

### DIFF
--- a/app/overrides/context_menus/issues.rb
+++ b/app/overrides/context_menus/issues.rb
@@ -2,5 +2,5 @@ Deface::Override.new :virtual_path => 'context_menus/issues',
                      :name         => 'hide-copy-issue-if-tracker-prevents-it',
                      :insert_bottom=> 'erb[loud]:contains("context_menu_link l(:button_copy)")',
                      :text         => <<-HIDE_LINK
-    if !@issue.tracker.prevent_copy_issues 
+    if @issue.present? && !@issue.tracker.prevent_copy_issues 
 HIDE_LINK

--- a/app/overrides/context_menus/issues.rb
+++ b/app/overrides/context_menus/issues.rb
@@ -1,6 +1,6 @@
 Deface::Override.new :virtual_path => 'context_menus/issues',
                      :name         => 'hide-copy-issue-if-tracker-prevents-it',
-                     :insert_bottom=> 'erb[loud]:contains("context_menu_link l(:button_copy)")',
+                     :insert_bottom=> 'erb[loud]:contains("context_menu_link l(:button_copy), project_copy_issue_path(@project, @issue)")',
                      :text         => <<-HIDE_LINK
-    if @issue.present? && !@issue.tracker.prevent_copy_issues 
+    if !@issue.tracker.prevent_copy_issues 
 HIDE_LINK

--- a/app/overrides/context_menus/issues.rb
+++ b/app/overrides/context_menus/issues.rb
@@ -1,0 +1,6 @@
+Deface::Override.new :virtual_path => 'context_menus/issues',
+                     :name         => 'hide-copy-issue-if-tracker-prevents-it',
+                     :insert_bottom=> 'erb[loud]:contains("context_menu_link l(:button_copy)")',
+                     :text         => <<-HIDE_LINK
+    if !@issue.tracker.prevent_copy_issues 
+HIDE_LINK

--- a/app/overrides/issues/_action_menu.rb
+++ b/app/overrides/issues/_action_menu.rb
@@ -2,5 +2,5 @@ Deface::Override.new :virtual_path => 'issues/_action_menu',
                      :name         => 'hide-copy-issue-if-tracker-prevents-it',
                      :insert_bottom=> 'erb[loud]:contains("link_to l(:button_copy)")',
                      :text         => <<-HIDE_LINK
-    && !@issue.tracker.prevent_copy_issues 
+    && @issue.present? && !@issue.tracker.prevent_copy_issues 
 HIDE_LINK

--- a/app/overrides/issues/_action_menu.rb
+++ b/app/overrides/issues/_action_menu.rb
@@ -2,5 +2,5 @@ Deface::Override.new :virtual_path => 'issues/_action_menu',
                      :name         => 'hide-copy-issue-if-tracker-prevents-it',
                      :insert_bottom=> 'erb[loud]:contains("link_to l(:button_copy)")',
                      :text         => <<-HIDE_LINK
-    && @issue.present? && !@issue.tracker.prevent_copy_issues 
+  && !@issue.tracker.prevent_copy_issues 
 HIDE_LINK

--- a/app/overrides/issues/_action_menu.rb
+++ b/app/overrides/issues/_action_menu.rb
@@ -1,0 +1,6 @@
+Deface::Override.new :virtual_path => 'issues/_action_menu',
+                     :name         => 'hide-copy-issue-if-tracker-prevents-it',
+                     :insert_bottom=> 'erb[loud]:contains("link_to l(:button_copy)")',
+                     :text         => <<-HIDE_LINK
+    && !@issue.tracker.prevent_copy_issues 
+HIDE_LINK

--- a/app/overrides/trackers/_form.rb
+++ b/app/overrides/trackers/_form.rb
@@ -1,0 +1,7 @@
+Deface::Override.new :virtual_path  => "trackers/_form",
+                     :name          => "add-prevent-copy-issues",
+                     :insert_after  => "p:eq(2)",
+                     :text          => <<-EOS
+<p><%= f.check_box :prevent_copy_issues %></p>
+EOS
+

--- a/db/migrate/20221004142452_add_trackers_prevent_copy_issues.rb
+++ b/db/migrate/20221004142452_add_trackers_prevent_copy_issues.rb
@@ -1,0 +1,5 @@
+class AddTrackersPreventCopyIssues < ActiveRecord::Migration[5.2]
+  def change
+    add_column :trackers, :prevent_copy_issues, :boolean, :default => false    
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -15,6 +15,7 @@ Rails.application.config.to_prepare do
   require_dependency 'redmine_tiny_features/time_entry_query_patch'
   require_dependency 'redmine_tiny_features/issues_helper_patch'
   require_dependency 'redmine_tiny_features/journal_patch'
+  require_dependency 'redmine_tiny_features/tracker_patch'
   require_dependency 'redmine_tiny_features/mailer_patch'
   require_dependency 'redmine_tiny_features/custom_field_enumeration_patch'
   require_dependency 'redmine_tiny_features/custom_field_patch'

--- a/lib/redmine_tiny_features/tracker_patch.rb
+++ b/lib/redmine_tiny_features/tracker_patch.rb
@@ -1,0 +1,3 @@
+class Tracker < ActiveRecord::Base	
+	safe_attributes('prevent_copy_issues')
+end

--- a/spec/models/tracker_query_spec.rb
+++ b/spec/models/tracker_query_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe "TrackerPatch" do
+  fixtures :trackers
+  
+  it "should Tracker#prevent_copy_issues" do
+    tracker = Tracker.find(1)
+    tracker.safe_attributes=({ "prevent_copy_issues" => 1 })
+    assert tracker.prevent_copy_issues
+    
+    tracker.safe_attributes=({ "prevent_copy_issues" => 0 })
+    assert !tracker.prevent_copy_issues
+  end
+end

--- a/spec/system/issues_spec.rb
+++ b/spec/system/issues_spec.rb
@@ -115,5 +115,37 @@ RSpec.describe "creating an issue", type: :system do
     end
   end
 
+  describe "option prevent copy issues" do
+    it "Show link copy when its tracker allows copy issues page(issue/show)" do
+      visit 'issues/2'
+      expect(page).to have_selector('a' , class: 'icon-copy', text: 'Copy')
+    end
+
+    it "Show link copy when its tracker allows copy issues page(issue/index)" do
+      visit 'issues/'
+      
+      find('tr#issue-2>td.buttons>a.icon-actions').click
+      expect(page).to have_selector('a.icon-copy')
+    end
+
+    it "Hide link copy when its tracker prevents copy issues page(issue/show)" do
+      tracker_test = Tracker.find(2)
+      tracker_test.prevent_copy_issues = true
+      tracker_test.save
+
+      visit 'issues/2'
+      expect(page).to_not have_selector('a', class: 'icon-copy', text: 'Copy')
+    end
+
+    it "Hide link copy when its tracker prevents copy issues page(issue/index)" do
+      tracker_test = Tracker.find(2)
+      tracker_test.prevent_copy_issues = true
+      tracker_test.save
+
+      visit 'issues/'      
+      find('tr#issue-2>td.buttons>a.icon-actions').click
+      expect(page).to_not have_selector('a.icon-copy')
+    end
+  end
 end
 


### PR DESCRIPTION
-Override les views context_menus/issues ,issues/_action_menu,trackers/_form par Deface::Override
- Ajouter le champ prevent_copy_issues pour le model tracker
- Test

