### PR TITLE
ticket#257121 Liste "demandes surveillées" bloquée au chargement - Filtre Observateur non optimisé

### DIFF
--- a/app/overrides/queries/_filters.rb
+++ b/app/overrides/queries/_filters.rb
@@ -31,6 +31,9 @@ Deface::Override.new :virtual_path  => "queries/_filters",
       if ($('#values_assigned_to_id_1').length > 0) {
         setConfigurationForSelect2($('#values_assigned_to_id_1'), '<%= assigned_to_values_pagination_path %>');
       }
+      if ($('#values_watcher_id_1').length > 0) {
+        setConfigurationForSelect2($('#values_watcher_id_1'), '<%= assigned_to_values_pagination_path %>');
+      }
     }
   }
 </script>

--- a/lib/redmine_tiny_features/issue_query_patch.rb
+++ b/lib/redmine_tiny_features/issue_query_patch.rb
@@ -5,6 +5,7 @@ class IssueQuery < Query
 
   alias :find_updated_by_filter_values :find_assigned_to_id_filter_values
   alias :find_last_updated_by_filter_values :find_assigned_to_id_filter_values
+  alias :find_watcher_id_filter_values :find_assigned_to_id_filter_values
 
 end
 
@@ -29,6 +30,10 @@ module RedmineTinyFeatures
           )
           add_available_filter(
             "last_updated_by",
+            :type => :list, :values => lambda { [] }
+          )
+          add_available_filter(
+            "watcher_id",
             :type => :list, :values => lambda { [] }
           )
         end

--- a/spec/models/issue_query_patch_spec.rb
+++ b/spec/models/issue_query_patch_spec.rb
@@ -11,52 +11,65 @@ describe "IssueQuery" do
     expect(issue_query.respond_to?('find_last_updated_by_filter_values')).to eq true
   end
 
-  it "should contain empty values for available_filter author_id, assigned_to_id, updated_by, last_updated_by" do
-
-    Setting["plugin_redmine_tiny_features"] = {
-      "warning_message_on_closed_issues"=>"1",
-      "default_open_status"=>"2",
-      "default_project"=>"1",
-      "use_select2"=>"1",
-      "paginate_issue_filters_values"=>"1"
-    }
-
+  it "should respond to find_watcher_id_filter_values" do
     issue_query = IssueQuery.new
-    expect(issue_query.available_filters["author_id"][:values]).to be_empty
-    expect(issue_query.available_filters["assigned_to_id"][:values]).to be_empty
-    expect(issue_query.available_filters["updated_by"][:values]).to be_empty
-    expect(issue_query.available_filters["last_updated_by"][:values]).to be_empty
+    expect(issue_query.respond_to?('find_watcher_id_filter_values')).to eq true
   end
 
-  it "should not contain empty values for available_filter author_id, assigned_to_id, updated_by, last_updated_by (use_select2 deactivated only)" do
+  context "available_filter" do
 
-    Setting["plugin_redmine_tiny_features"] = {
-      "warning_message_on_closed_issues"=>"1",
-      "default_open_status"=>"2",
-      "default_project"=>"1",
-      "paginate_issue_filters_values"=>"1"
-    }
+    before do
+      User.current = User.find(1)
+    end
+    
+    it "should contain empty values for available_filter author_id, assigned_to_id, updated_by, last_updated_by" do
+      Setting["plugin_redmine_tiny_features"] = {
+        "warning_message_on_closed_issues"=>"1",
+        "default_open_status"=>"2",
+        "default_project"=>"1",
+        "use_select2"=>"1",
+        "paginate_issue_filters_values"=>"1"
+      }
 
-    issue_query = IssueQuery.new
-    expect(issue_query.available_filters["author_id"][:values]).not_to be_empty
-    expect(issue_query.available_filters["assigned_to_id"][:values]).not_to be_empty
-    expect(issue_query.available_filters["updated_by"][:values]).not_to be_empty
-    expect(issue_query.available_filters["last_updated_by"][:values]).not_to be_empty
+      issue_query = IssueQuery.new
+      expect(issue_query.available_filters["author_id"][:values]).to be_empty
+      expect(issue_query.available_filters["assigned_to_id"][:values]).to be_empty
+      expect(issue_query.available_filters["updated_by"][:values]).to be_empty
+      expect(issue_query.available_filters["last_updated_by"][:values]).to be_empty
+      expect(issue_query.available_filters["watcher_id"][:values]).to be_empty
+    end
+
+    it "should not contain empty values for available_filter author_id, assigned_to_id, updated_by, last_updated_by,watcher_id (use_select2 deactivated only)" do
+
+      Setting["plugin_redmine_tiny_features"] = {
+        "warning_message_on_closed_issues"=>"1",
+        "default_open_status"=>"2",
+        "default_project"=>"1",
+        "paginate_issue_filters_values"=>"1"
+      }
+
+      issue_query = IssueQuery.new
+      expect(issue_query.available_filters["author_id"][:values]).not_to be_empty
+      expect(issue_query.available_filters["assigned_to_id"][:values]).not_to be_empty
+      expect(issue_query.available_filters["updated_by"][:values]).not_to be_empty
+      expect(issue_query.available_filters["last_updated_by"][:values]).not_to be_empty
+      expect(issue_query.available_filters["watcher_id"][:values]).not_to be_empty 
+    end
+
+    it "should not contain empty values for available_filter author_id, assigned_to_id, updated_by, last_updated_by,watcher_id (use_select2 and paginate_issue_filters_values deactivated)" do
+
+      Setting["plugin_redmine_tiny_features"] = {
+        "warning_message_on_closed_issues"=>"1",
+        "default_open_status"=>"2",
+        "default_project"=>"1",
+      }
+
+      issue_query = IssueQuery.new
+      expect(issue_query.available_filters["author_id"][:values]).not_to be_empty
+      expect(issue_query.available_filters["assigned_to_id"][:values]).not_to be_empty
+      expect(issue_query.available_filters["updated_by"][:values]).not_to be_empty
+      expect(issue_query.available_filters["last_updated_by"][:values]).not_to be_empty
+      expect(issue_query.available_filters["watcher_id"][:values]).not_to be_empty
+    end
   end
-
-  it "should not contain empty values for available_filter author_id, assigned_to_id, updated_by, last_updated_by (use_select2 and paginate_issue_filters_values deactivated)" do
-
-    Setting["plugin_redmine_tiny_features"] = {
-      "warning_message_on_closed_issues"=>"1",
-      "default_open_status"=>"2",
-      "default_project"=>"1",
-    }
-
-    issue_query = IssueQuery.new
-    expect(issue_query.available_filters["author_id"][:values]).not_to be_empty
-    expect(issue_query.available_filters["assigned_to_id"][:values]).not_to be_empty
-    expect(issue_query.available_filters["updated_by"][:values]).not_to be_empty
-    expect(issue_query.available_filters["last_updated_by"][:values]).not_to be_empty
-  end
-
 end


### PR DESCRIPTION
- Appliquer la pagination sur le champ de watcher_id de issue_query
 - Test

