### PR TITLE
Ticket 317396,Masquer les membres sur la page d'apercu d'un projet 

### DIFF
--- a/.github/workflows/4_2_11.yml
+++ b/.github/workflows/4_2_11.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Prepare Redmine source
         working-directory: redmine
         run: |
+          # TODO Remove the following line when https://www.redmine.org/issues/40551 is fixed
+          sed -i -e 's/.*mocha.*/  gem "mocha", "2.1.0"/' Gemfile # Fix core tests not compatible with Mocha 2.2.0
           sed -i '/rubocop/d' Gemfile
           rm -f .rubocop*
           cp plugins/redmine_base_rspec/spec/support/database-${{ matrix.db }}.yml config/database.yml

--- a/.github/workflows/5_1_2.yml
+++ b/.github/workflows/5_1_2.yml
@@ -90,6 +90,8 @@ jobs:
         working-directory: redmine
         run: |
           rm -f test/integration/routing/plugins_test.rb # Fix routing tests # TODO Remove this line when https://www.redmine.org/issues/38707 is fixed
+          # TODO Remove the following line when https://www.redmine.org/issues/40551 is fixed
+          sed -i -e 's/.*mocha.*/  gem "mocha", "2.1.0"/' Gemfile # Fix core tests not compatible with Mocha 2.2.0
           sed -i '/rubocop/d' Gemfile
           rm -f .rubocop*
           cp plugins/redmine_base_rspec/spec/support/database-${{ matrix.db }}.yml config/database.yml

--- a/app/overrides/projects/show.rb
+++ b/app/overrides/projects/show.rb
@@ -1,0 +1,8 @@
+Deface::Override.new :virtual_path  => 'projects/show',
+                     :name          => 'hide-members-on-project-overview',
+                     :surround      => "erb[loud]:contains('members_box')",
+                     :text          => <<-EOS
+<% if !Setting["plugin_redmine_tiny_features"]["hide_members_section_in_overview_project"].present? %>
+  <%= render_original %>
+<% end %>
+EOS

--- a/app/views/settings/_redmine_plugin_tiny_features_settings.html.erb
+++ b/app/views/settings/_redmine_plugin_tiny_features_settings.html.erb
@@ -73,6 +73,12 @@
     <%= l("setting_load_issue_edit_form_asynchronously") %>
   <% end %>
 </p>
+<p>
+  <%= label_tag '', { style: 'width: auto;' } do %>
+    <%= check_box_tag "settings[hide_members_section_in_overview_project]", '1', Setting["plugin_redmine_tiny_features"]["hide_members_section_in_overview_project"] %>
+    <%= l("enable_members_in_overview_project") %>
+  <% end %>
+</p>
 
 <%= javascript_tag do %>
   $(function() {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,3 +40,4 @@ en:
   label_issue_display_by_priority: "Colorization According to priority"
   label_issue_display_by_status: "Colorization According to status"
   field_show_pagination_at_top_results: "Show pagination links at the top of issues results"
+  enable_members_in_overview_project: "Hides members section on project overview page"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -40,3 +40,4 @@ fr:
   label_issue_display_by_priority: "Colorisation par priorité"
   label_issue_display_by_status: "Colorisation par statut"
   field_show_pagination_at_top_results: "Afficher les liens de pagination en haut des résultats des demandes"
+  enable_members_in_overview_project: "Masquer la section des membres sur la page d'apercu d'un projet"

--- a/spec/system/projects_spec.rb
+++ b/spec/system/projects_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+RSpec.describe "ProjectController", type: :system do
+
+  fixtures :users, :user_preferences, :projects, :members, :roles, :member_roles
+
+  before do
+    log_user('admin', 'admin')
+  end
+
+  describe "Option to hide/show the members section on the overview page of each project" do
+    let(:project_test) { Project.find(1) }
+
+    it "Should hide members section when the option is activated" do
+
+      Setting.send "plugin_redmine_tiny_features=", {
+        "hide_members_section_in_overview_project" => "1",
+      }
+
+      visit "/projects/#{project_test.identifier}"
+      expect(page).to_not have_selector('div.members')
+
+    end
+
+    it "Should display members section when the option is deactivated" do
+
+      Setting.send "plugin_redmine_tiny_features=", {
+        "hide_members_section_in_overview_project" => "",
+      }
+
+      visit "/projects/#{project_test.identifier}"
+      expect(page).to have_selector('div.members')
+    end
+
+  end
+end

--- a/spec/system/settings_redmine_tiny_features_spec.rb
+++ b/spec/system/settings_redmine_tiny_features_spec.rb
@@ -37,4 +37,21 @@ RSpec.describe "settings_redmine_tiny_features", type: :system do
       "load_issue_edit_form_asynchronously" => "0",
     }
   end
+
+  it "activates the option  hide_members_section_in_overview_project" do
+    log_user('admin', 'admin')
+
+    visit 'settings/plugin/redmine_tiny_features'
+
+    find("input[name='settings[hide_members_section_in_overview_project]']").click
+    find("input[name='commit']").click
+
+    expect(Setting["plugin_redmine_tiny_features"]["hide_members_section_in_overview_project"]).to eq '1'
+    Setting.send "plugin_redmine_tiny_features=", {
+      "warning_message_on_closed_issues" => "1",
+      "default_open_status" => "2",
+      "default_project" => "1",
+      "hide_members_section_in_overview_project" => "0",
+    }
+  end
 end


### PR DESCRIPTION
 - Ajouter l'option "Masquer la section des membres sur la page d'aperçu d'un projet"
- Test