### PR TITLE
Masquage du champ Statut lorsqu'il n'est pas modifiable : déplacer du plugin SCN vers TinyFeatures

### DIFF
--- a/app/overrides/issues/_attributes.rb
+++ b/app/overrides/issues/_attributes.rb
@@ -1,0 +1,9 @@
+Deface::Override.new :virtual_path  => "issues/_attributes",
+                     :name          => "hide_read_only_status_field",
+                     :original      => '8c07bc5c6125db54af3873465088717987a73827',
+                     :remove        => "p:contains('l(:field_status)')"
+
+Deface::Override.new :virtual_path  => "issues/_form_with_positions",
+                     :name          => "hide_read_only_status_field",
+                     :original      => '8c07bc5c6125db54af3873465088717987a73827',
+                     :remove        => "p:contains('l(:field_status)')"

--- a/spec/system/issues_spec.rb
+++ b/spec/system/issues_spec.rb
@@ -233,4 +233,26 @@ RSpec.describe "creating an issue", type: :system do
       expect(options).to eq (options.sort_by(&:parameterize))
     end
   end
+
+  describe "status field" do
+    let (:issue_test) { Issue.find(9) }
+
+    before do
+      visit 'logout/'
+      find('input[name=commit]').click
+      log_user('jsmith', 'jsmith')
+    end
+
+    it "Should hide the Status field when it is not editable" do
+      WorkflowTransition.delete_all
+      issue_test
+      visit "/issues/#{issue_test.id}/edit"
+      expect(page).to_not have_selector('label', text: "Status")
+    end
+
+    it "Should show the Status field when it is editable" do
+      visit "/issues/#{issue_test.id}/edit"
+      expect(page).to have_selector('label', text: "Status *")
+    end
+  end
 end


### PR DESCRIPTION
… plugin SCN vers TinyFeatures